### PR TITLE
Feat/유저용(Public) M클래스 API 구현

### DIFF
--- a/src/api/internal/mclass/mclass.router.ts
+++ b/src/api/internal/mclass/mclass.router.ts
@@ -17,10 +17,10 @@ const service = new MClassService(repository);
 const controller = new MClassController(service);
 
 mclassRegistry.registerPath({
-	summary: 'm클래스 생성',
+	summary: 'Internal m클래스 생성',
 	method: 'post',
 	path: '/internal/mclasses',
-	tags: ['MClass'],
+	tags: ['Internal-MClass'],
 	security: [{ bearerAuth: [] }],
 	request: {
 		body: {
@@ -34,10 +34,10 @@ mclassRegistry.registerPath({
 mclassRouter.post('/', isAuth, isAdmin, validateBody(PostCreateMClassRequestDto.toSchema()), controller.create);
 
 mclassRegistry.registerPath({
-	summary: 'm클래스 삭제',
+	summary: 'Internal m클래스 삭제',
 	method: 'delete',
 	path: '/internal/mclasses/{id}',
-	tags: ['MClass'],
+	tags: ['Internal-MClass'],
 	security: [{ bearerAuth: [] }],
 	request: {
 		params: z.object({ id: commonValidations.id }),

--- a/src/api/open-api/open-api-document-generator.ts
+++ b/src/api/open-api/open-api-document-generator.ts
@@ -1,34 +1,45 @@
-import { OpenAPIRegistry, OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
-import { healthCheckRegistry } from '../health-check';
-import { mclassRegistry } from '../internal';
-import { authRegistry, userRegistry } from '../public';
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV3,
+} from "@asteasolutions/zod-to-openapi";
+import { healthCheckRegistry } from "../health-check";
+import { mclassRegistry } from "../internal";
+import { authRegistry, publicMclassRegistry, userRegistry } from "../public";
 
-export type OpenAPIDocument = ReturnType<OpenApiGeneratorV3['generateDocument']>;
+export type OpenAPIDocument = ReturnType<
+  OpenApiGeneratorV3["generateDocument"]
+>;
 
 export function generateOpenAPIDocument(): OpenAPIDocument {
-	const registry = new OpenAPIRegistry([healthCheckRegistry, userRegistry, authRegistry, mclassRegistry]);
-	// 보안 스키마는 레지스트리에 컴포넌트로 등록
-	registry.registerComponent('securitySchemes', 'bearerAuth', {
-		type: 'http',
-		scheme: 'bearer',
-		bearerFormat: 'JWT',
-		description: 'Input your JWT token in the format: Bearer <token>',
-	});
+  const registry = new OpenAPIRegistry([
+    healthCheckRegistry,
+    userRegistry,
+    authRegistry,
+    mclassRegistry,
+    publicMclassRegistry,
+  ]);
+  // 보안 스키마는 레지스트리에 컴포넌트로 등록
+  registry.registerComponent("securitySchemes", "bearerAuth", {
+    type: "http",
+    scheme: "bearer",
+    bearerFormat: "JWT",
+    description: "Input your JWT token in the format: Bearer <token>",
+  });
 
-	const generator = new OpenApiGeneratorV3(registry.definitions);
-	const doc = generator.generateDocument({
-		openapi: '3.0.0',
-		info: {
-			version: '1.0.0',
-			title: 'Swagger API',
-		},
-		externalDocs: {
-			description: 'View the raw OpenAPI Specification in JSON format',
-			url: '/docs.json',
-		},
-	});
+  const generator = new OpenApiGeneratorV3(registry.definitions);
+  const doc = generator.generateDocument({
+    openapi: "3.0.0",
+    info: {
+      version: "1.0.0",
+      title: "Swagger API",
+    },
+    externalDocs: {
+      description: "View the raw OpenAPI Specification in JSON format",
+      url: "/docs.json",
+    },
+  });
 
-	// 전역 보안 적용 (타입 제한 회피를 위해 생성 후 주입)
-	// (doc as any).security = [{ bearerAuth: [] }];
-	return doc;
+  // 전역 보안 적용 (타입 제한 회피를 위해 생성 후 주입)
+  // (doc as any).security = [{ bearerAuth: [] }];
+  return doc;
 }

--- a/src/api/public/index.ts
+++ b/src/api/public/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
+export * from './mclass/mclass.router';
 export * from './user';

--- a/src/api/public/mclass/dto/command/apply-mclass-command.dto.ts
+++ b/src/api/public/mclass/dto/command/apply-mclass-command.dto.ts
@@ -1,0 +1,3 @@
+export class ApplyMClassCommand {
+  constructor(readonly mclassId: string, readonly userId: string) {}
+}

--- a/src/api/public/mclass/dto/index.ts
+++ b/src/api/public/mclass/dto/index.ts
@@ -1,6 +1,6 @@
 export * from './info/get-mclass-detail-info.dto';
-export * from './info/get-mclass-detail-info.dto';
 export * from './info/get-mclasses-info.dto';
 export * from './request/get-mclasses-query.dto';
 export * from './response/get-mclass-detail-response.dto';
 export * from './response/get-mclasses-response.dto';
+export * from './response/post-apply-mclass-response.dto';

--- a/src/api/public/mclass/dto/index.ts
+++ b/src/api/public/mclass/dto/index.ts
@@ -1,0 +1,6 @@
+export * from './info/get-mclass-detail-info.dto';
+export * from './info/get-mclass-detail-info.dto';
+export * from './info/get-mclasses-info.dto';
+export * from './request/get-mclasses-query.dto';
+export * from './response/get-mclass-detail-response.dto';
+export * from './response/get-mclasses-response.dto';

--- a/src/api/public/mclass/dto/info/get-mclass-detail-info.dto.ts
+++ b/src/api/public/mclass/dto/info/get-mclass-detail-info.dto.ts
@@ -1,0 +1,49 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+import type { MClassEntity } from '@/orm';
+
+export class MClassDetailInfo
+	implements Pick<MClassEntity, 'id' | 'title' | 'description' | 'maxParticipants' | 'createdAt' | 'startAt' | 'endAt'>
+{
+	constructor(
+		readonly id: string,
+		readonly title: string,
+		readonly description: string | null,
+		readonly maxParticipants: number,
+		readonly createdAt: Date,
+		readonly startAt: Date | null,
+		readonly endAt: Date | null,
+	) {}
+
+	static fromEntity(entity: MClassEntity): MClassDetailInfo;
+	static fromEntity(entity: MClassEntity[]): MClassDetailInfo[];
+	static fromEntity(entity: MClassEntity | MClassEntity[]): MClassDetailInfo | MClassDetailInfo[] {
+		if (Array.isArray(entity)) {
+			return entity.map((e) => MClassDetailInfo.fromEntity(e));
+		}
+		return new MClassDetailInfo(
+			entity.id,
+			entity.title,
+			entity.description ?? null,
+			entity.maxParticipants,
+			entity.createdAt,
+			entity.startAt ?? null,
+			entity.endAt ?? null,
+		);
+	}
+
+	static toSchema(): z.ZodTypeAny {
+		return z.object({
+			id: z.string().describe('m클래스 ID'),
+			title: z.string().describe('m클래스 제목'),
+			description: z.string().nullable().describe('m클래스 설명'),
+			maxParticipants: z.number().describe('최대 참가자 수'),
+			createdAt: z.date().describe('생성일'),
+			startAt: z.date().nullable().describe('시작일'),
+			endAt: z.date().nullable().describe('종료일'),
+		});
+	}
+}

--- a/src/api/public/mclass/dto/info/get-mclasses-info.dto.ts
+++ b/src/api/public/mclass/dto/info/get-mclasses-info.dto.ts
@@ -1,0 +1,45 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { MClassEntity } from '@/orm';
+
+extendZodWithOpenApi(z);
+
+export class GetMClassesInfo
+	implements Pick<MClassEntity, 'id' | 'title' | 'maxParticipants' | 'createdAt' | 'startAt' | 'endAt'>
+{
+	constructor(
+		readonly id: string,
+		readonly title: string,
+		readonly maxParticipants: number,
+		readonly createdAt: Date,
+		readonly startAt: Date | null,
+		readonly endAt: Date | null,
+	) {}
+
+	static fromEntity(entity: MClassEntity): GetMClassesInfo;
+	static fromEntity(entity: MClassEntity[]): GetMClassesInfo[];
+	static fromEntity(entity: MClassEntity | MClassEntity[]): GetMClassesInfo | GetMClassesInfo[] {
+		if (Array.isArray(entity)) {
+			return entity.map((e) => GetMClassesInfo.fromEntity(e));
+		}
+		return new GetMClassesInfo(
+			entity.id,
+			entity.title,
+			entity.maxParticipants,
+			entity.createdAt,
+			entity.startAt ?? null,
+			entity.endAt ?? null,
+		);
+	}
+
+	static toSchema(): z.ZodTypeAny {
+		return z.object({
+			id: z.string().describe('m클래스 ID'),
+			title: z.string().describe('m클래스 제목'),
+			maxParticipants: z.number().describe('최대 참가자 수'),
+			createdAt: z.date().describe('생성일'),
+			startAt: z.date().nullable().describe('시작일'),
+			endAt: z.date().nullable().describe('종료일'),
+		});
+	}
+}

--- a/src/api/public/mclass/dto/request/get-mclasses-query.dto.ts
+++ b/src/api/public/mclass/dto/request/get-mclasses-query.dto.ts
@@ -1,0 +1,20 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import z from 'zod';
+
+extendZodWithOpenApi(z);
+
+export class GetMClassesQueryDto {
+	constructor(
+		readonly page: number = 1,
+		readonly pageSize: number = 20,
+	) {}
+
+	static toSchema(): typeof GetMClassesQuerySchema {
+		return GetMClassesQuerySchema;
+	}
+}
+
+export const GetMClassesQuerySchema = z.object({
+	page: z.coerce.number().int().positive().default(1),
+	pageSize: z.coerce.number().int().positive().max(100).default(20),
+});

--- a/src/api/public/mclass/dto/response/get-mclass-detail-response.dto.ts
+++ b/src/api/public/mclass/dto/response/get-mclass-detail-response.dto.ts
@@ -1,18 +1,18 @@
 import type { z } from 'zod';
-import { MClassInfo } from '@/api/internal';
 import { ResponseDto } from '@/common';
+import { MClassDetailInfo } from '../info/get-mclass-detail-info.dto';
 
-export class GetMClassDetailResponseDto extends ResponseDto<MClassInfo> {
-	constructor(readonly info: MClassInfo) {
+export class GetMClassDetailResponseDto extends ResponseDto<MClassDetailInfo> {
+	constructor(readonly info: MClassDetailInfo) {
 		super(info);
 	}
 
-	static of(info: MClassInfo): GetMClassDetailResponseDto {
+	static of(info: MClassDetailInfo): GetMClassDetailResponseDto {
 		const dto = new GetMClassDetailResponseDto(info);
 		return GetMClassDetailResponseDto.toSchema().parse(dto);
 	}
 
 	static toSchema(): z.ZodTypeAny {
-		return ResponseDto.toSchema(MClassInfo.toSchema());
+		return ResponseDto.toSchema(MClassDetailInfo.toSchema());
 	}
 }

--- a/src/api/public/mclass/dto/response/get-mclass-detail-response.dto.ts
+++ b/src/api/public/mclass/dto/response/get-mclass-detail-response.dto.ts
@@ -1,0 +1,18 @@
+import type { z } from 'zod';
+import { MClassInfo } from '@/api/internal';
+import { ResponseDto } from '@/common';
+
+export class GetMClassDetailResponseDto extends ResponseDto<MClassInfo> {
+	constructor(readonly info: MClassInfo) {
+		super(info);
+	}
+
+	static of(info: MClassInfo): GetMClassDetailResponseDto {
+		const dto = new GetMClassDetailResponseDto(info);
+		return GetMClassDetailResponseDto.toSchema().parse(dto);
+	}
+
+	static toSchema(): z.ZodTypeAny {
+		return ResponseDto.toSchema(MClassInfo.toSchema());
+	}
+}

--- a/src/api/public/mclass/dto/response/get-mclasses-response.dto.ts
+++ b/src/api/public/mclass/dto/response/get-mclasses-response.dto.ts
@@ -1,0 +1,20 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import { ResponseDto } from '@/common';
+import { GetMClassesInfo } from '../info/get-mclasses-info.dto';
+
+extendZodWithOpenApi(z);
+
+export class GetMClassesResponseDto extends ResponseDto<GetMClassesInfo> {
+	constructor(readonly info: GetMClassesInfo) {
+		super(info);
+	}
+
+	static of(info: GetMClassesInfo[]): GetMClassesResponseDto[] {
+		return info.map((i) => new GetMClassesResponseDto(i));
+	}
+
+	static toSchema(): z.ZodTypeAny {
+		return ResponseDto.toSchema(GetMClassesInfo.toSchema());
+	}
+}

--- a/src/api/public/mclass/dto/response/get-mclasses-response.dto.ts
+++ b/src/api/public/mclass/dto/response/get-mclasses-response.dto.ts
@@ -11,7 +11,8 @@ export class GetMClassesResponseDto extends ResponseDto<GetMClassesInfo> {
 	}
 
 	static of(info: GetMClassesInfo[]): GetMClassesResponseDto[] {
-		return info.map((i) => new GetMClassesResponseDto(i));
+		const dtoList = info.map((i) => new GetMClassesResponseDto(i));
+		return dtoList.map((i) => GetMClassesResponseDto.toSchema().parse(i));
 	}
 
 	static toSchema(): z.ZodTypeAny {

--- a/src/api/public/mclass/dto/response/post-apply-mclass-response.dto.ts
+++ b/src/api/public/mclass/dto/response/post-apply-mclass-response.dto.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { ResponseDto } from "@/common";
+
+export class PostApplyMClassResponseDto extends ResponseDto<{
+  applicationId: string;
+}> {
+  constructor(applicationId: string) {
+    super({ applicationId });
+  }
+
+  static of(applicationId: string): PostApplyMClassResponseDto {
+    return new PostApplyMClassResponseDto(applicationId);
+  }
+
+  static toSchema(): z.ZodTypeAny {
+    return ResponseDto.toSchema(z.object({ applicationId: z.string() }));
+  }
+}

--- a/src/api/public/mclass/mclass.controller.ts
+++ b/src/api/public/mclass/mclass.controller.ts
@@ -1,0 +1,20 @@
+import type { Request, RequestHandler, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { GetMClassDetailResponseDto, type GetMClassesQueryDto, GetMClassesResponseDto } from './dto';
+import type { PublicMClassService } from './mclass.service';
+
+export class PublicMClassController {
+	constructor(private readonly service: PublicMClassService) {}
+
+	public list: RequestHandler = async (req: Request, res: Response) => {
+		const query = req.query as unknown as GetMClassesQueryDto;
+		const info = await this.service.getList(query);
+		return res.status(StatusCodes.OK).send(GetMClassesResponseDto.of(info));
+	};
+
+	public detail: RequestHandler = async (req: Request, res: Response) => {
+		const id = req.params.id as string;
+		const info = await this.service.getDetail(id);
+		return res.status(StatusCodes.OK).send(GetMClassDetailResponseDto.of(info));
+	};
+}

--- a/src/api/public/mclass/mclass.controller.ts
+++ b/src/api/public/mclass/mclass.controller.ts
@@ -1,6 +1,8 @@
 import type { Request, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { GetMClassDetailResponseDto, type GetMClassesQueryDto, GetMClassesResponseDto } from './dto';
+import { ApplyMClassCommand } from './dto/command/apply-mclass-command.dto';
+import { PostApplyMClassResponseDto } from './dto/response/post-apply-mclass-response.dto';
 import type { PublicMClassService } from './mclass.service';
 
 export class PublicMClassController {
@@ -16,5 +18,12 @@ export class PublicMClassController {
 		const id = req.params.id as string;
 		const info = await this.service.getDetail(id);
 		return res.status(StatusCodes.OK).send(GetMClassDetailResponseDto.of(info));
+	};
+
+	public apply: RequestHandler = async (req: Request, res: Response) => {
+		const userId = req.user?.id as string;
+		const mclassId = req.params.id as string;
+		const applicationId = await this.service.apply(new ApplyMClassCommand(mclassId, userId));
+		return res.status(StatusCodes.CREATED).send(PostApplyMClassResponseDto.of(applicationId));
 	};
 }

--- a/src/api/public/mclass/mclass.repository.ts
+++ b/src/api/public/mclass/mclass.repository.ts
@@ -1,0 +1,45 @@
+import type { Repository } from 'typeorm';
+import { ResourceNotFoundException } from '@/common';
+import type { MClassEntity } from '@/orm';
+
+export type CreateMClassParams = Pick<
+	MClassEntity,
+	'title' | 'description' | 'maxParticipants' | 'startAt' | 'endAt' | 'hostId'
+>;
+
+export type FindMClassesOptions = { page: number; pageSize: number };
+
+export type MClassRepository = {
+	create(params: CreateMClassParams): Promise<MClassEntity>;
+	findById(id: string): Promise<MClassEntity>;
+	deleteById(id: string): Promise<void>;
+	findPage(options: FindMClassesOptions): Promise<[MClassEntity[], number]>;
+};
+
+export class MClassCoreRepository implements MClassRepository {
+	constructor(private readonly repo: Repository<MClassEntity>) {}
+
+	async create(params: CreateMClassParams): Promise<MClassEntity> {
+		const entity = this.repo.create(params);
+		return await this.repo.save(entity);
+	}
+
+	async findById(id: string): Promise<MClassEntity> {
+		const found = await this.repo.findOne({ where: { id } });
+		if (!found) throw new ResourceNotFoundException('MClass가 존재하지 않습니다.');
+		return found;
+	}
+
+	async deleteById(id: string): Promise<void> {
+		const result = await this.repo.delete({ id });
+		if (!result.affected) throw new ResourceNotFoundException('MClass가 존재하지 않습니다.');
+	}
+
+	async findPage({ page, pageSize }: FindMClassesOptions): Promise<[MClassEntity[], number]> {
+		return await this.repo.findAndCount({
+			order: { createdAt: 'DESC' },
+			skip: (page - 1) * pageSize,
+			take: pageSize,
+		});
+	}
+}

--- a/src/api/public/mclass/mclass.router.ts
+++ b/src/api/public/mclass/mclass.router.ts
@@ -1,9 +1,14 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import express, { type Router } from 'express';
 import { z } from 'zod';
-import { createApiResponse, validateParams, validateQuery } from '@/common';
+import { createApiResponse, isAuth, validateParams, validateQuery } from '@/common';
 import { MClassEntity, OrmDataSource } from '@/orm';
-import { GetMClassDetailResponseDto, GetMClassesQuerySchema, GetMClassesResponseDto } from './dto';
+import {
+	GetMClassDetailResponseDto,
+	GetMClassesQuerySchema,
+	GetMClassesResponseDto,
+	PostApplyMClassResponseDto,
+} from './dto';
 import { PublicMClassController } from './mclass.controller';
 import { MClassCoreRepository } from './mclass.repository';
 import { PublicMClassService } from './mclass.service';
@@ -33,4 +38,15 @@ publicMclassRegistry.registerPath({
 	request: { params: z.object({ id: z.string() }) },
 	responses: createApiResponse(GetMClassDetailResponseDto.toSchema(), 'Success', 200),
 });
-publicMclassRouter.get('/mclasses/:id', validateParams(z.object({ id: z.string() })), controller.detail);
+publicMclassRouter.get('/mclasses/:id', controller.detail);
+
+publicMclassRegistry.registerPath({
+	summary: 'm클래스 신청',
+	method: 'post',
+	path: '/mclasses/{id}/apply',
+	tags: ['MClass'],
+	request: { params: z.object({ id: z.string() }) },
+	security: [{ bearerAuth: [] }],
+	responses: createApiResponse(PostApplyMClassResponseDto.toSchema(), 'Created', 201),
+});
+publicMclassRouter.post('/mclasses/:id/apply', isAuth, controller.apply);

--- a/src/api/public/mclass/mclass.router.ts
+++ b/src/api/public/mclass/mclass.router.ts
@@ -1,0 +1,36 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import express, { type Router } from 'express';
+import { z } from 'zod';
+import { createApiResponse, validateParams, validateQuery } from '@/common';
+import { MClassEntity, OrmDataSource } from '@/orm';
+import { GetMClassDetailResponseDto, GetMClassesQuerySchema, GetMClassesResponseDto } from './dto';
+import { PublicMClassController } from './mclass.controller';
+import { MClassCoreRepository } from './mclass.repository';
+import { PublicMClassService } from './mclass.service';
+
+export const publicMclassRegistry = new OpenAPIRegistry();
+export const publicMclassRouter: Router = express.Router();
+
+const repository = new MClassCoreRepository(OrmDataSource.getRepository(MClassEntity));
+const service = new PublicMClassService(repository);
+const controller = new PublicMClassController(service);
+
+publicMclassRegistry.registerPath({
+	summary: 'm클래스 목록 조회',
+	method: 'get',
+	path: '/mclasses',
+	tags: ['MClass'],
+	request: { query: GetMClassesQuerySchema },
+	responses: createApiResponse(GetMClassesResponseDto.toSchema(), 'Success', 200),
+});
+publicMclassRouter.get('/mclasses', validateQuery(GetMClassesQuerySchema), controller.list);
+
+publicMclassRegistry.registerPath({
+	summary: 'm클래스 상세 조회',
+	method: 'get',
+	path: '/mclasses/{id}',
+	tags: ['MClass'],
+	request: { params: z.object({ id: z.string() }) },
+	responses: createApiResponse(GetMClassDetailResponseDto.toSchema(), 'Success', 200),
+});
+publicMclassRouter.get('/mclasses/:id', validateParams(z.object({ id: z.string() })), controller.detail);

--- a/src/api/public/mclass/mclass.service.ts
+++ b/src/api/public/mclass/mclass.service.ts
@@ -1,0 +1,17 @@
+import { GetMClassesInfo, type GetMClassesQueryDto, MClassDetailInfo } from './dto';
+import type { MClassRepository } from './mclass.repository';
+
+export class PublicMClassService {
+	constructor(private readonly repository: MClassRepository) {}
+
+	async getList(query: GetMClassesQueryDto): Promise<GetMClassesInfo[]> {
+		const { page, pageSize } = query;
+		const [rows] = await this.repository.findPage({ page, pageSize });
+		return GetMClassesInfo.fromEntity(rows);
+	}
+
+	async getDetail(id: string): Promise<MClassDetailInfo> {
+		const entity = await this.repository.findById(id);
+		return MClassDetailInfo.fromEntity(entity);
+	}
+}

--- a/src/api/public/mclass/mclass.service.ts
+++ b/src/api/public/mclass/mclass.service.ts
@@ -1,4 +1,7 @@
+import { ConflictStatusException, ResourceNotFoundException } from '@/common';
+import { ApplicationEntity, MClassEntity, OrmDataSource } from '@/orm';
 import { GetMClassesInfo, type GetMClassesQueryDto, MClassDetailInfo } from './dto';
+import type { ApplyMClassCommand } from './dto/command/apply-mclass-command.dto';
 import type { MClassRepository } from './mclass.repository';
 
 export class PublicMClassService {
@@ -13,5 +16,45 @@ export class PublicMClassService {
 	async getDetail(id: string): Promise<MClassDetailInfo> {
 		const entity = await this.repository.findById(id);
 		return MClassDetailInfo.fromEntity(entity);
+	}
+
+	/**
+	 * 신청(응모) - 동시성 고려
+	 * - UNIQUE(userId, mclassId)로 중복 방지
+	 * - 단일 트랜잭션에서 mclass 정원 확인 후 INSERT + appliedCount 증가
+	 */
+	async apply(command: ApplyMClassCommand): Promise<string> {
+		return await OrmDataSource.transaction(async (manager) => {
+			const txMClassRepo = manager.getRepository(MClassEntity);
+			const txAppRepo = manager.getRepository(ApplicationEntity);
+
+			// 1) 대상 클래스 잠금(비관적 락)
+			const mclass = await txMClassRepo.findOne({
+				where: { id: command.mclassId },
+				lock: { mode: 'pessimistic_write' },
+			});
+			if (!mclass) throw new ResourceNotFoundException('클래스가 존재하지 않습니다.');
+			if (!mclass.isActive()) throw new ConflictStatusException('신청 가능 상태가 아닙니다.');
+			if (mclass.isFull()) throw new ConflictStatusException('정원이 초과되었습니다.');
+			if (mclass.isEnded()) throw new ConflictStatusException('이미 종료된 클래스입니다.');
+
+			// 3) 신청 INSERT (UNIQUE 충돌 시 에러)
+			try {
+				const application = txAppRepo.create({
+					userId: command.userId,
+					mclassId: command.mclassId,
+				});
+				const saved = await txAppRepo.save(application);
+				// 4) appliedCount 증가
+				await txMClassRepo.increment({ id: command.mclassId }, 'appliedCount', 1);
+				return saved.id;
+			} catch (e: any) {
+				// MySQL duplicate key
+				if (e?.code === 'ER_DUP_ENTRY' || e?.errno === 1062) {
+					throw new ConflictStatusException('이미 신청된 클래스입니다.');
+				}
+				throw e;
+			}
+		});
 	}
 }

--- a/src/common/middleware/request-logger.ts
+++ b/src/common/middleware/request-logger.ts
@@ -41,6 +41,9 @@ const httpLogger = pinoHttp({
 			url: req.url,
 			id: req.id,
 		}),
+		res: (res) => ({
+			statusCode: res.statusCode,
+		}),
 	},
 });
 

--- a/src/orm/entity/MClass.entity.ts
+++ b/src/orm/entity/MClass.entity.ts
@@ -47,4 +47,16 @@ export class MClassEntity {
 	@ManyToOne(() => UserEntity, { onDelete: 'RESTRICT', eager: false })
 	@JoinColumn({ name: 'hostId', referencedColumnName: 'id' })
 	host!: UserEntity;
+
+	isActive(): boolean {
+		return !!this.startAt && !!this.endAt && this.startAt <= new Date() && this.endAt >= new Date();
+	}
+
+	isFull(): boolean {
+		return this.appliedCount >= this.maxParticipants;
+	}
+
+	isEnded(): boolean {
+		return !!this.endAt && this.endAt <= new Date();
+	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import express, { type Express } from 'express';
 import helmet from 'helmet';
 import { pino } from 'pino';
 
-import { healthCheckRouter, openAPIRouter, userRouter } from '@/api';
+import { healthCheckRouter, openAPIRouter, publicMclassRouter, userRouter } from '@/api';
 import { authRouter } from '@/api/public/auth';
 import { env, errorHandler, rateLimiter, requestLogger } from '@/common';
 import { mclassRouter } from './api/internal';
@@ -27,6 +27,7 @@ app.use(requestLogger);
 app.use('/health-check', healthCheckRouter);
 app.use('/users', userRouter);
 app.use('/auth', authRouter);
+app.use('/', publicMclassRouter);
 
 // Internal API
 app.use('/internal/mclasses', mclassRouter);


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가(테스트 추가) — 신규 테스트 케이스는 포함되지 않음
- [ ] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> 커밋(최신 → 과거)
> - 44820bb feat: 잘못된 export 제거와 http 로그 간소화
> - 2075e8c feat: m클래스 신청 API 완료
> - 483358d feat: 유저용 mclass 조회 API 구현

- 공개용 MClass API 신규
  - GET `/mclasses`: 페이지네이션 목록 조회
    - 쿼리: `page(기본 1, >0)`, `pageSize(기본 20, >0, ≤100)`
    - 반환: `[{ id, title, maxParticipants, createdAt, startAt?, endAt? }]`
    - 구현: `publicMclassRouter.get('/mclasses', ...)` + `validateQuery(GetMClassesQuerySchema)`
    - 레포지토리: `findAndCount` 기반 페이지 조회
  - GET `/mclasses/:id`: 상세 조회
    - 반환: `{ id, title, description?, maxParticipants, createdAt, startAt?, endAt? }`
    - 자원 부재 시 404 (레포지토리에서 `ResourceNotFoundException`)
  - POST `/mclasses/:id/apply` (보안: Bearer 토큰 필요)
    - 동시성/정합성 고려한 신청(아래 상세)
    - 성공 시 201 `{ applicationId }`, 중복/정원 초과/기간 문제는 409
- 동시성/정합성(핵심)
  - 단일 트랜잭션에서 처리: 대상 `mclasses` 행에 비관적 락(`pessimistic_write`) → 상태 검증 → `applications` INSERT → `mclasses.appliedCount` 증가
  - `(userId, mclassId)` 유니크 제약 충돌 시 MySQL 1062를 캐치하여 409로 매핑
  - 클래스 상태 체크:
    - `isActive()`: 신청 가능 기간 여부
    - `isFull()`: `appliedCount >= maxParticipants`
    - `isEnded()`: 종료 시각 경과 여부
- 문서/라우팅
  - OpenAPI: `publicMclassRegistry` 경로/스키마 등록, `bearerAuth` 컴포넌트 유지
  - 서버: `publicMclassRouter`를 `/`에 연결하여 `/mclasses` 계열 경로 노출
- 로깅
  - 요청 로거 개선: 요청 ID 주입, 상태 코드 기반 로그 레벨, 개발환경 응답 바디 캡처
- 기타
  - `MClassEntity`에 상태 판별 메서드 추가(`isActive`, `isFull`, `isEnded`)
  - 내보내기 정리(`src/api/public/index.ts`)

### 동시성 시퀀스 (신청)
```mermaid
%%{init: {'theme': 'dark'}}%%
sequenceDiagram
  participant C as Client(User)
  participant API as Express
  participant S as PublicMClassService
  participant DS as OrmDataSource.tx
  participant M as Repo<MClass>
  participant A as Repo<Application>
  participant DB as MySQL(InnoDB)

  C->>API: POST /mclasses/:id/apply (Bearer)
  API->>S: apply({ mclassId, userId })
  S->>DS: transaction(...)
  DS->>M: findOne({ id }, lock: pessimistic_write)
  M-->>DS: mclass row
  DS->>DS: isActive && !isFull && !isEnded 검증
  alt valid
    DS->>A: INSERT applications(userId, mclassId)
    alt duplicate (ER_DUP_ENTRY/1062)
      A-->>DS: error
      DS-->>S: throw 409 AlreadyApplied
    else inserted
      DS->>M: increment appliedCount by 1
      DS-->>S: applicationId
    end
  else invalid
    DS-->>S: throw 409 (CLASS_FULL or NOT_ACTIVE/ENDED)
  end
  S-->>API: 201 { applicationId }
  API-->>C: 201 Created
```

## 2️⃣ 작업내용 추가 설명
- 요구사항 맵핑
  - 참조: `docs/250810-1-요구사항.md`, `docs/250810-2-요구사항-해결을-위한-설계.md`
  - 유저용 MClass
    - 목록/상세/신청 API 제공(요구사항 1.2 및 6장 정의 반영)
    - 페이지네이션 및 스키마 검증(zod) 적용
  - 동시성/정합성
    - 설계서 1.5/3.3/7.x의 정책 준수: 트랜잭션, 락, 유니크 제약, 상태 검증
    - 에러 매핑: 유니크 충돌→409, 정원 초과/기간 문제→409, 미존재→404
- 보안/운영
  - 신청은 `isAuth` 요구, 문서에 `bearerAuth` 반영
  - 요청 ID 로깅 및 상태 기반 로그 레벨로 운영 가시성 향상
- 스키마/타입
  - DTO 분리(Command/Info/Response)로 문서화/테스트 용이
  - `GetMClassesQuerySchema`로 입력 위생화(기본값/범위 한정)

## 3️⃣ 이슈
- 경합 구간 재시도 정책
  - 현재는 비관적 락 + 단일 트랜잭션 처리. 데드락/락 타임아웃 발생 시 재시도 로직은 서비스 레벨에 미도입(추가 가능)
- appliedCount와 소스오브트루스
  - 현재 `applications` INSERT 후 `appliedCount`를 증가시키는 카운터 캐시 전략. 보고용 정확도 보장을 위해 주기적 동기화/검증(선택)
- 필터링/검색 고도화
  - 목록 검색은 기본 페이지네이션만 제공. `q`, `기간 필터`, `hostId` 등은 확장 포인트
