### PR TITLE
Feat/user applications api 신규 추가와 클래스 신청 동시성 테스트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,363 @@
-# pre-openknowl
+# 요구사항 해결을 위한 설계
 
-(주) 오픈놀 과제
+## 1. 요구사항 분석
+
+### 1.1 도메인/역할/용어
+- 사용자 역할: Guest(비회원), User(일반), Host(개설자), Admin(관리자)
+- 핵심 개념: `MClass(강의)`, `Application(신청)`, `User(사용자)`
+- 파생 개념: 정원(`maxParticipants`), 현재 신청 수(`appliedCount` 집계 또는 `Application` 카운트), 기간(`startAt`/`endAt`)
+
+### 1.2 기능 요구사항(8개 API)
+- Auth: 회원가입 `POST /api/auth/signup`, 로그인 `POST /api/auth/signin`
+- User: 내 신청내역 `GET /api/users/me/applications`
+- MClass(User): 목록 `GET /api/mclasses`, 상세 `GET /api/mclasses/:id`, 신청 `POST /api/mclasses/:id/apply`
+- MClass(Admin/Host): 생성 `POST /api/internal/mclasses`, 삭제 `DELETE /api/internal/mclasses/:id`
+
+### 1.3 제약/가정
+- 인증: JWT Bearer, 비밀번호는 `bcrypt` 해시 저장
+- 데이터 건수: `MClass` 수만~수십만, `Application` 수백만 가정
+- 중복 신청 방지: `(userId, mclassId)` 유니크 제약
+- 정원 초과 방지: 트랜잭션 + 락/버전으로 보호
+- 정책: 호스트 본인 수강 신청 불가, 삭제는 `Admin` 또는 소유자만
+
+### 1.4 비기능 요구사항
+- 보안: 입력 검증, 비밀번호 안전 저장, 최소 권한(인가), 토큰 만료/회수 전략
+- 성능: 인덱스/페이징 최적화, N+1 방지, 캐시 고려(선택)
+- 동시성: 단일 DB 트랜잭션으로 임계구역 보호, 데드락 재시도, 유니크 충돌 처리
+- 가용성/운영: 헬스체크, 표준 에러 포맷 `{code, message, details?}`, 구조적 로깅
+
+### 1.5 동시성 정책(권장안)
+- 기본: InnoDB 트랜잭션 + `SELECT ... FOR UPDATE`로 대상 `MClass` 행 잠금 → 정원 확인 → `Application` INSERT(유니크 보장) → 필요 시 `MClass.applied_count` 증가 → 커밋
+- 대안(낙관적): `MClass.version`을 조건으로 UPDATE(`WHERE id=? AND version=?`)하여 정원 증감 시 버전 충돌을 감지(충돌 시 재시도)
+- 운영 팁: 데드락/락타임아웃은 1~3회 재시도, 응답은 409(CONFLICT)로 표준화
+
+## 2. 유스케이스
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+graph TD
+    subgraph Actors
+      G[Guest]
+      U[User]
+      A[Admin]
+    end
+
+    subgraph System
+      S1[(Auth)]
+      S2[(MClass Service)]
+      S3[(Application Service)]
+    end
+
+    G -->|signup/signin| S1
+    U -->|list/detail| S2
+    U -->|apply| S3
+    A -->|create/delete| S2
+```
+
+요약
+- Guest: 회원가입/로그인
+- User: 목록/상세/신청, 내 신청내역
+- Admin: M클래스 생성/삭제
+
+## 3. 시퀀스 다이어그램
+
+### 3.1 로그인(Signin)
+```mermaid
+%%{init: {'theme':'dark'}}%%
+sequenceDiagram
+    participant C as Client
+    participant API as Auth API
+    participant DB as MySQL
+    participant JWT as JWT Service
+
+    C->>API: POST /api/auth/signin {email, password}
+    API->>DB: SELECT user WHERE email
+    DB-->>API: user + passwordHash
+    API->>API: bcrypt.compare()
+    alt valid
+        API->>JWT: sign({sub:userId, role:isAdmin?})
+        JWT-->>API: accessToken
+        API-->>C: 200 {accessToken}
+    else invalid
+        API-->>C: 401 AUTH_INVALID_CREDENTIALS
+    end
+```
+
+### 3.2 m클래스 목록/상세
+```mermaid
+%%{init: {'theme':'dark'}}%%
+sequenceDiagram
+    participant C as Client
+    participant API as MClass API
+    participant DB as MySQL
+
+    C->>API: GET /api/mclasses?q=...&page=...&limit=...
+    API->>DB: SELECT ... WHERE filters ORDER BY created_at DESC LIMIT/OFFSET
+    DB-->>API: rows + total
+    API-->>C: 200 {data, page, limit, total}
+
+    C->>API: GET /api/mclasses/:id
+    API->>DB: SELECT mclass BY id
+    API->>DB: SELECT COUNT(*) FROM applications WHERE mclass_id=:id
+    DB-->>API: entity + appliedCount
+    API-->>C: 200 {..., appliedCount, isFull}
+```
+
+### 3.3 신청(Apply) - 트랜잭션/락
+```mermaid
+%%{init: {'theme':'dark'}}%%
+sequenceDiagram
+    participant C as Client
+    participant API as Application API
+    participant DB as MySQL(InnoDB)
+
+    C->>API: POST /api/mclasses/:id/apply (JWT)
+    API->>DB: BEGIN
+    API->>DB: SELECT * FROM mclasses WHERE id=:id FOR UPDATE
+    DB-->>API: mclass(row)
+    API->>API: validate(host/self, period)
+    alt notFull
+        API->>DB: INSERT INTO applications(user_id, mclass_id) VALUES ...
+        alt unique violation
+            DB-->>API: 1062 duplicate key
+            API-->>C: 409 ALREADY_APPLIED
+        else inserted
+            API->>DB: UPDATE mclasses SET applied_count=applied_count+1 WHERE id=:id
+            API->>DB: COMMIT
+            API-->>C: 201 {applicationId}
+        end
+    else full
+        API->>DB: ROLLBACK
+        API-->>C: 409 CLASS_FULL
+    end
+```
+
+## 4. 도메인 관점 클래스 다이어그램
+
+```mermaid
+%%{init: {'theme':'dark'}}%%
+classDiagram
+    class User {
+        +id: string
+        +email: string
+        +passwordHash: string
+        +isAdmin: boolean
+        +createdAt: Date
+        +updatedAt: Date
+    }
+
+    class Period {
+        +startAt: Date
+        +endAt: Date
+        +includes(date: Date) bool
+        +isValid() bool
+    }
+
+    class MClass {
+        +id: string
+        +title: string
+        +description: string
+        +maxParticipants: number
+        +appliedCount: number
+        +hostId: string
+        +version: number
+        +period: Period
+        +incrementApplied(): void
+        +isFull(): bool
+        +isHost(userId: string): bool
+    }
+
+    class Application {
+        +id: string
+        +userId: string
+        +mclassId: string
+        +createdAt: Date
+    }
+
+    class EnrollmentPolicy {
+        +assertCanApply(userId: string, m: MClass): void
+    }
+
+    class EnrollmentService {
+        +apply(userId: string, mclassId: string): string
+    }
+
+    MClass o-- Period
+    EnrollmentService ..> EnrollmentPolicy
+```
+
+설명
+- 애그리게잇 루트: `MClass`(정원/버전/정책 연관). 신청은 `Application`으로 분리되지만, 정원 검사는 `MClass` 기준으로 보호
+- 도메인 서비스 `EnrollmentPolicy`는 호스트 본인 신청 금지, 기간 유효성 등을 캡슐화
+
+## 5. 상태 다이어그램
+
+### 5.1 인증 상태
+```mermaid
+%%{init: {'theme':'dark'}}%%
+stateDiagram-v2
+    [*] --> UNAUTHENTICATED
+    UNAUTHENTICATED --> AUTHENTICATED : 로그인 성공
+    AUTHENTICATED --> UNAUTHENTICATED : 토큰 만료/검증 실패/로그아웃
+```
+
+### 5.2 m클래스 라이프사이클(파생)
+```mermaid
+%%{init: {'theme':'dark'}}%%
+stateDiagram-v2
+    [*] --> NONE: 관리자 생성
+    NONE --> OPEN: 현재 시간이 startAt 이후
+    OPEN --> FULL : appliedCount >= maxParticipants
+    OPEN --> CLOSED : 현재 시간이 endAt 이후
+    FULL --> CLOSED : 현재 시간이 endAt 이후
+    CLOSED --> ARCHIVED : 보관(운영)
+```
+
+## 6. API 정의서(요약)
+
+- 공통: 응답 에러 포맷 `{code, message, details?}`. 인증이 필요한 API는 `Authorization: Bearer <token>`
+
+### Auth API
+1) POST `/api/auth/signup`
+   - Auth: Public
+   - Body: `{ email: string, password: string }`
+   - 201: `{ userId: string }`
+   - 409: `CONFLICT_DUPLICATE_EMAIL`, 400: `VALIDATION_ERROR`
+
+2) POST `/api/auth/signin`
+   - Auth: Public
+   - Body: `{ email: string, password: string }`
+   - 200: `{ accessToken: string }`
+   - 401: `AUTH_INVALID_CREDENTIALS`, 400: `VALIDATION_ERROR`
+
+### User API
+1) GET `/api/users/me/applications`
+   - Auth: Required
+   - Query: `page?, limit?`
+   - 200: `{ data: Application[], page, limit, total }`
+   - 401: `AUTH_REQUIRED`
+
+### M클래스 API - 유저
+1) GET `/api/mclasses`
+   - Auth: Optional
+   - Query: `q?, hostId?, from?, to?, page=1, limit<=100`
+   - 200: `{ data: MClass[], page, limit, total }`
+
+2) GET `/api/mclasses/:id`
+   - Auth: Optional
+   - 200: `MClassDetail & { appliedCount: number, isFull: boolean }`
+   - 404: `MCLASS_NOT_FOUND`
+
+3) POST `/api/mclasses/:id/apply`
+   - Auth: Required
+   - 201: `{ applicationId: string }`
+   - 400: `HOST_CANNOT_APPLY`, 404: `MCLASS_NOT_FOUND`
+   - 409: `ALREADY_APPLIED | CLASS_FULL`
+
+### M클래스 API - 내부용
+4) POST `/api/internal/mclasses`
+   - Auth: Required(Host/Admin)
+   - Body: `{ title, description?, maxParticipants, startAt?, endAt? }`
+   - 201: `{ id: string }`
+   - 400: `VALIDATION_ERROR`
+
+5) DELETE `/api/internal/mclasses/:id`
+   - Auth: Required(Admin or Owner)
+   - 204: no body
+   - 403: `CLASS_FORBIDDEN`, 404: `MCLASS_NOT_FOUND`
+
+## 7. 논리/물리 ERD 설계 (MySQL 8)
+
+### 7.1 논리 ERD
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+erDiagram
+  USER ||--o{ APPLICATION : applies
+  MCLASS ||--o{ APPLICATION : receives
+  USER ||--o{ MCLASS : hosts
+
+  USER {
+    string id PK
+    string email UK
+    string passwordHash
+    boolean isAdmin
+    datetime createdAt
+    datetime updatedAt
+  }
+
+  MCLASS {
+    string id PK
+    string title
+    string description
+    int maxParticipants
+    int appliedCount
+    string hostId FK
+    int version
+    datetime startAt
+    datetime endAt
+    datetime createdAt
+    datetime updatedAt
+  }
+
+  APPLICATION {
+    string id PK
+    string userId FK
+    string mclassId FK
+    datetime createdAt
+  }
+```
+
+### 7.2 물리 설계(DDL 스케치)
+```sql
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  createdAt DATETIME(6) NOT NULL,
+  updatedAt DATETIME(6) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  passwordHash VARCHAR(100) NOT NULL,
+  isAdmin TINYINT(1) NOT NULL DEFAULT 0,
+  INDEX idx_users_created_at (createdAt)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE mclasses (
+  id bigint PRIMARY KEY,
+  createdAt DATETIME(6) NOT NULL,
+  updatedAt DATETIME(6) NOT NULL,
+  title VARCHAR(200) NOT NULL,
+  description TEXT NULL,
+  maxParticipants INT UNSIGNED NOT NULL,
+  appliedCount INT UNSIGNED NOT NULL DEFAULT 0,
+  hostId CHAR(26) NOT NULL,
+  version INT UNSIGNED NOT NULL DEFAULT 0,
+  startAt DATETIME(6) NULL,
+  endAt DATETIME(6) NULL,
+  CONSTRAINT fk_mclass_host FOREIGN KEY (hostId) REFERENCES users(id),
+  INDEX idx_mclasses_host (hostId),
+  INDEX idx_mclasses_period (startAt, endAt),
+  FULLTEXT INDEX ftx_mclasses_title (title)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE applications (
+  id bigint PRIMARY KEY,
+  createdAt DATETIME(6) NOT NULL,
+  updatedAt DATETIME(6) NOT NULL,
+  userId bigint NOT NULL,
+  mclassId bigint NOT NULL,
+  CONSTRAINT fk_app_user FOREIGN KEY (userId) REFERENCES users(id),
+  CONSTRAINT fk_app_class FOREIGN KEY (mclassId) REFERENCES mclasses(id),
+  UNIQUE KEY uk_app_user_class (userId, mclassId),
+  INDEX idx_app_user (userId),
+  INDEX idx_app_class (mclassId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+인덱스/동시성 메모
+- `uk_app_user_class`로 중복 신청 방지
+- 신청 트랜잭션에서 `SELECT ... FOR UPDATE`로 대상 `mclasses` 행 잠금 후 `applied_count` 갱신
+- 대체안: `applied_count` 미보유 시 `SELECT COUNT(*) FROM applications WHERE mclass_id=?`를 사용하되, 트랜잭션 내 일관성 보장 필요
+- `version` 칼럼은 낙관적 락(확장 시) 적용 가능
+
+## 8. 운영/품질 가이드(요약)
+- 환경변수 검증 후 부팅 실패 전략(불완전 구성 차단)
+- 표준 에러 코드: AUTH_INVALID_CREDENTIALS, AUTH_REQUIRED, MCLASS_NOT_FOUND, CLASS_FORBIDDEN, CLASS_FULL, ALREADY_APPLIED, HOST_CANNOT_APPLY, CONFLICT_DUPLICATE_EMAIL, VALIDATION_ERROR
+- 테스트: 단위/통합에서 동시 신청 케이스, 유니크 충돌, 정원 경합, 권한 확인

--- a/src/api/public/user/dto/index.ts
+++ b/src/api/public/user/dto/index.ts
@@ -1,2 +1,4 @@
-export * from './info/get-user-info.dto';
-export * from './response/get-user-response.dto';
+export * from "./info/get-user-info.dto";
+export * from "./response/get-user-response.dto";
+export * from "./info/get-my-application-info.dto";
+export * from "./response/get-my-applications-response.dto";

--- a/src/api/public/user/dto/info/get-my-application-info.dto.ts
+++ b/src/api/public/user/dto/info/get-my-application-info.dto.ts
@@ -1,0 +1,32 @@
+import z from "zod";
+import type { ApplicationEntity, MClassEntity } from "@/orm";
+
+export class GetMyApplicationInfo {
+  constructor(
+    readonly applicationId: string,
+    readonly mclassId: string,
+    readonly title: string,
+    readonly appliedAt: Date
+  ) {}
+
+  static fromEntities(
+    app: ApplicationEntity,
+    mclass: MClassEntity
+  ): GetMyApplicationInfo {
+    return new GetMyApplicationInfo(
+      app.id,
+      mclass.id,
+      mclass.title,
+      app.createdAt
+    );
+  }
+
+  static toSchema(): z.ZodTypeAny {
+    return z.object({
+      applicationId: z.string(),
+      mclassId: z.string(),
+      title: z.string(),
+      appliedAt: z.date(),
+    });
+  }
+}

--- a/src/api/public/user/dto/response/get-my-applications-response.dto.ts
+++ b/src/api/public/user/dto/response/get-my-applications-response.dto.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { ResponseDto } from "@/common";
+import { GetMyApplicationInfo } from "../info/get-my-application-info.dto";
+
+export class GetMyApplicationsResponseDto extends ResponseDto<
+  GetMyApplicationInfo[]
+> {
+  constructor(infos: GetMyApplicationInfo[]) {
+    super(infos);
+  }
+
+  static of(infos: GetMyApplicationInfo[]): GetMyApplicationsResponseDto {
+    return new GetMyApplicationsResponseDto(infos);
+  }
+
+  static toSchema(): z.ZodTypeAny {
+    return ResponseDto.toSchema(z.array(GetMyApplicationInfo.toSchema()));
+  }
+}

--- a/src/api/public/user/user.controller.ts
+++ b/src/api/public/user/user.controller.ts
@@ -1,15 +1,26 @@
-import type { Request, RequestHandler, Response } from 'express';
-import { StatusCodes } from 'http-status-codes';
-import { GetUserResponseDto } from './dto';
-import type { UserService } from './user.service';
+import type { Request, RequestHandler, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { GetMyApplicationsResponseDto, GetUserResponseDto } from "./dto";
+import type { UserService } from "./user.service";
 
 export class UserController {
-	constructor(private readonly userService: UserService) {}
+  constructor(private readonly userService: UserService) {}
 
-	public getUser: RequestHandler = async (req: Request, res: Response) => {
-		// '/users/me' 경로는 JWT에서 주입된 req.id를 사용
-		const id = req.user?.id as string;
-		const userInfo = await this.userService.getById(id);
-		return res.status(StatusCodes.OK).send(GetUserResponseDto.of(userInfo));
-	};
+  public getUser: RequestHandler = async (req: Request, res: Response) => {
+    // '/users/me' 경로는 JWT에서 주입된 req.id를 사용
+    const id = req.user?.id as string;
+    const userInfo = await this.userService.getById(id);
+    return res.status(StatusCodes.OK).send(GetUserResponseDto.of(userInfo));
+  };
+
+  public getMyApplications: RequestHandler = async (
+    req: Request,
+    res: Response
+  ) => {
+    const userId = req.user?.id as string;
+    const infos = await this.userService.getMyApplications(userId);
+    return res
+      .status(StatusCodes.OK)
+      .send(GetMyApplicationsResponseDto.of(infos));
+  };
 }

--- a/src/api/public/user/user.repository.ts
+++ b/src/api/public/user/user.repository.ts
@@ -1,32 +1,58 @@
-import type { Repository } from 'typeorm';
-import { ResourceNotFoundException } from '@/common';
-import type { UserEntity } from '@/orm';
+import type { Repository } from "typeorm";
+import { ResourceNotFoundException } from "@/common";
+import type { ApplicationEntity, MClassEntity, UserEntity } from "@/orm";
 
-export type FindWhereOptions = Partial<Pick<UserEntity, 'email' | 'id'>>;
-export type CreateUserParams = Pick<UserEntity, 'email' | 'passwordHash'>;
+export type FindWhereOptions = Partial<Pick<UserEntity, "email" | "id">>;
+export type CreateUserParams = Pick<UserEntity, "email" | "passwordHash">;
 
 export type UserRepository = {
-	exists(options: FindWhereOptions): Promise<boolean>;
-	findBy(options: FindWhereOptions): Promise<UserEntity>;
-	create(params: CreateUserParams): Promise<UserEntity>;
+  exists(options: FindWhereOptions): Promise<boolean>;
+  findBy(options: FindWhereOptions): Promise<UserEntity>;
+  create(params: CreateUserParams): Promise<UserEntity>;
+  findMyApplications(
+    userId: string
+  ): Promise<Array<{ application: ApplicationEntity; mclass: MClassEntity }>>;
 };
 
 export class UserCoreRepository implements UserRepository {
-	constructor(private readonly ormUserRepo: Repository<UserEntity>) {}
+  constructor(private readonly ormUserRepo: Repository<UserEntity>) {}
 
-	async exists(options: FindWhereOptions): Promise<boolean> {
-		const user = await this.ormUserRepo.findOneBy(options);
-		return user !== null;
-	}
+  async exists(options: FindWhereOptions): Promise<boolean> {
+    const user = await this.ormUserRepo.findOneBy(options);
+    return user !== null;
+  }
 
-	async findBy(options: FindWhereOptions): Promise<UserEntity> {
-		const user = await this.ormUserRepo.findOneBy(options);
-		if (!user) throw new ResourceNotFoundException();
-		return user;
-	}
+  async findBy(options: FindWhereOptions): Promise<UserEntity> {
+    const user = await this.ormUserRepo.findOneBy(options);
+    if (!user) throw new ResourceNotFoundException();
+    return user;
+  }
 
-	async create(params: CreateUserParams): Promise<UserEntity> {
-		const user = this.ormUserRepo.create(params);
-		return await this.ormUserRepo.save(user);
-	}
+  async create(params: CreateUserParams): Promise<UserEntity> {
+    const user = this.ormUserRepo.create(params);
+    return await this.ormUserRepo.save(user);
+  }
+
+  async findMyApplications(
+    userId: string
+  ): Promise<Array<{ application: ApplicationEntity; mclass: MClassEntity }>> {
+    const appRepo = this.ormUserRepo.manager.getRepository<ApplicationEntity>(
+      "applications" as any
+    );
+    const mclassRepo = this.ormUserRepo.manager.getRepository<MClassEntity>(
+      "mclasses" as any
+    );
+
+    const applications = await appRepo.find({
+      where: { userId } as any,
+      order: { createdAt: "DESC" } as any,
+    });
+    if (applications.length === 0) return [];
+    const mclassIds = applications.map((a) => a.mclassId);
+    const mclasses = await mclassRepo.findBy({ id: mclassIds as any } as any);
+    const mclassMap = new Map(mclasses.map((m) => [m.id, m]));
+    return applications
+      .map((a) => ({ application: a, mclass: mclassMap.get(a.mclassId)! }))
+      .filter((pair) => !!pair.mclass);
+  }
 }

--- a/src/api/public/user/user.router.ts
+++ b/src/api/public/user/user.router.ts
@@ -1,17 +1,20 @@
-import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
-import express, { type Router } from 'express';
-import { createApiResponse, isAuth } from '@/common';
-import { OrmDataSource, UserEntity } from '@/orm';
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import express, { type Router } from "express";
+import { createApiResponse, isAuth } from "@/common";
+import { GetMyApplicationsResponseDto } from "./dto";
+import { OrmDataSource, UserEntity } from "@/orm";
 
-import { GetUserResponseDto } from './dto';
-import { UserController } from './user.controller';
-import { UserCoreRepository } from './user.repository';
-import { UserService } from './user.service';
+import { GetUserResponseDto } from "./dto";
+import { UserController } from "./user.controller";
+import { UserCoreRepository } from "./user.repository";
+import { UserService } from "./user.service";
 
 export const userRegistry = new OpenAPIRegistry();
 export const userRouter: Router = express.Router();
 
-const userRepository = new UserCoreRepository(OrmDataSource.getRepository(UserEntity));
+const userRepository = new UserCoreRepository(
+  OrmDataSource.getRepository(UserEntity)
+);
 const userService = new UserService(userRepository);
 const userController = new UserController(userService);
 
@@ -24,14 +27,26 @@ const userController = new UserController(userService);
 
 // userRouter.get('/', userController.getUsers);
 
-userRegistry.register('GetUserResponse', GetUserResponseDto.toSchema());
+userRegistry.register("GetUserResponse", GetUserResponseDto.toSchema());
 userRegistry.registerPath({
-	method: 'get',
-	path: '/users/me',
-	tags: ['User'],
-	security: [{ bearerAuth: [] }],
-	responses: createApiResponse(GetUserResponseDto.toSchema(), 'Success'),
+  method: "get",
+  path: "/users/me",
+  tags: ["User"],
+  security: [{ bearerAuth: [] }],
+  responses: createApiResponse(GetUserResponseDto.toSchema(), "Success"),
 });
 
 // jwt(id)를 문자열로 검증
-userRouter.get('/me', isAuth, userController.getUser);
+userRouter.get("/me", isAuth, userController.getUser);
+
+userRegistry.registerPath({
+  method: "get",
+  path: "/users/me/applications",
+  tags: ["User"],
+  security: [{ bearerAuth: [] }],
+  responses: createApiResponse(
+    GetMyApplicationsResponseDto.toSchema(),
+    "Success"
+  ),
+});
+userRouter.get("/me/applications", isAuth, userController.getMyApplications);

--- a/src/api/public/user/user.service.ts
+++ b/src/api/public/user/user.service.ts
@@ -1,16 +1,23 @@
-import { GetUserInfo } from './dto';
-import type { UserRepository } from './user.repository';
+import { GetMyApplicationInfo, GetUserInfo } from "./dto";
+import type { UserRepository } from "./user.repository";
 
 export class UserService {
-	constructor(private readonly repository: UserRepository) {}
+  constructor(private readonly repository: UserRepository) {}
 
-	async getByEmail(email: string): Promise<GetUserInfo> {
-		const user = await this.repository.findBy({ email });
-		return GetUserInfo.fromEntity(user);
-	}
+  async getByEmail(email: string): Promise<GetUserInfo> {
+    const user = await this.repository.findBy({ email });
+    return GetUserInfo.fromEntity(user);
+  }
 
-	async getById(id: string): Promise<GetUserInfo> {
-		const user = await this.repository.findBy({ id });
-		return GetUserInfo.fromEntity(user);
-	}
+  async getById(id: string): Promise<GetUserInfo> {
+    const user = await this.repository.findBy({ id });
+    return GetUserInfo.fromEntity(user);
+  }
+
+  async getMyApplications(userId: string): Promise<GetMyApplicationInfo[]> {
+    const pairs = await this.repository.findMyApplications(userId);
+    return pairs.map(({ application, mclass }) =>
+      GetMyApplicationInfo.fromEntities(application, mclass)
+    );
+  }
 }

--- a/test/integration/mclass/public-mclass.concurrency.integration.spec.ts
+++ b/test/integration/mclass/public-mclass.concurrency.integration.spec.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { ApplyMClassCommand } from '../../../src/api/public/mclass/dto/command/apply-mclass-command.dto';
+import { MClassCoreRepository } from '../../../src/api/public/mclass/mclass.repository';
+import { PublicMClassService } from '../../../src/api/public/mclass/mclass.service';
+import { ApplicationEntity, MClassEntity, OrmDataSource, UserEntity } from '../../../src/orm/index';
+
+describe('PublicMClassService concurrency', () => {
+	let service: PublicMClassService;
+
+	beforeAll(async () => {
+		if (!OrmDataSource.isInitialized) {
+			await OrmDataSource.initialize();
+		}
+		await OrmDataSource.synchronize(true);
+		service = new PublicMClassService(new MClassCoreRepository(OrmDataSource.getRepository(MClassEntity)));
+	});
+
+	afterAll(async () => {
+		if (OrmDataSource.isInitialized) await OrmDataSource.destroy();
+	});
+
+	beforeEach(async () => {
+		await OrmDataSource.manager.clear(ApplicationEntity);
+		await OrmDataSource.manager.clear(MClassEntity);
+		await OrmDataSource.manager.clear(UserEntity);
+	});
+
+	it('동시에 여러 명이 신청하면 첫 번째만 성공한다', async () => {
+		// Given
+		const host = await OrmDataSource.manager.save(
+			OrmDataSource.manager.create(UserEntity, {
+				email: 'host@example.com',
+				passwordHash: 'x',
+			}),
+		);
+		const mclass = await OrmDataSource.manager.save(
+			OrmDataSource.manager.create(MClassEntity, {
+				title: 'Concurrency Class',
+				description: null,
+				maxParticipants: 1,
+				hostId: host.id,
+			}),
+		);
+
+		const userIds = Array.from({ length: 50 }, (_, i) => i + 1);
+		await Promise.all(
+			userIds.map((i) =>
+				OrmDataSource.manager.save(
+					OrmDataSource.manager.create(UserEntity, {
+						email: `u${i}@ex.com`,
+						passwordHash: 'x',
+					}),
+				),
+			),
+		);
+
+		const results = await Promise.allSettled(
+			userIds.map((_, idx) => service.apply(new ApplyMClassCommand(mclass.id, String(idx + 1)))),
+		);
+
+		const success = results.filter((r) => r.status === 'fulfilled');
+		const failed = results.filter((r) => r.status === 'rejected');
+		expect(success.length).toBe(1);
+		expect(failed.length).toBe(userIds.length - 1);
+	});
+});

--- a/test/integration/mclass/public-mclass.service.integration.spec.ts
+++ b/test/integration/mclass/public-mclass.service.integration.spec.ts
@@ -1,0 +1,214 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { ApplyMClassCommand } from "../../../src/api/public/mclass/dto/command/apply-mclass-command.dto";
+import { MClassCoreRepository } from "../../../src/api/public/mclass/mclass.repository";
+import { PublicMClassService } from "../../../src/api/public/mclass/mclass.service";
+import {
+  ConflictStatusException,
+  ResourceNotFoundException,
+} from "../../../src/common";
+import {
+  ApplicationEntity,
+  MClassEntity,
+  OrmDataSource,
+  UserEntity,
+} from "../../../src/orm/index";
+
+describe("PublicMClassService integration", () => {
+  let service: PublicMClassService;
+
+  beforeAll(async () => {
+    if (!OrmDataSource.isInitialized) {
+      await OrmDataSource.initialize();
+    }
+    await OrmDataSource.synchronize(true);
+    service = new PublicMClassService(
+      new MClassCoreRepository(OrmDataSource.getRepository(MClassEntity))
+    );
+  });
+
+  afterAll(async () => {
+    if (OrmDataSource.isInitialized) await OrmDataSource.destroy();
+  });
+
+  beforeEach(async () => {
+    await OrmDataSource.manager.clear(ApplicationEntity);
+    await OrmDataSource.manager.clear(MClassEntity);
+    await OrmDataSource.manager.clear(UserEntity);
+  });
+
+  it("신청 성공 - 빈 클래스에 첫 신청", async () => {
+    // Given
+    const host = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "host@example.com",
+        passwordHash: "x",
+      })
+    );
+    const user = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "user1@example.com",
+        passwordHash: "x",
+      })
+    );
+    const mclass = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(MClassEntity, {
+        title: "Test Class",
+        description: null,
+        maxParticipants: 10,
+        hostId: host.id,
+      })
+    );
+
+    // When
+    const applicationId = await service.apply(
+      new ApplyMClassCommand(mclass.id, user.id)
+    );
+
+    // Then
+    expect(applicationId).toBeDefined();
+    const application = await OrmDataSource.manager.findOneBy(
+      ApplicationEntity,
+      { id: applicationId }
+    );
+    expect(application?.userId).toBe(user.id);
+    expect(application?.mclassId).toBe(mclass.id);
+  });
+
+  it("중복 신청은 409 에러", async () => {
+    // Given
+    const host = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "host2@example.com",
+        passwordHash: "x",
+      })
+    );
+    const user = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "user2@example.com",
+        passwordHash: "x",
+      })
+    );
+    const mclass = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(MClassEntity, {
+        title: "Dup Class",
+        description: null,
+        maxParticipants: 10,
+        hostId: host.id,
+      })
+    );
+
+    await service.apply(new ApplyMClassCommand(mclass.id, user.id));
+    await expect(
+      service.apply(new ApplyMClassCommand(mclass.id, user.id))
+    ).rejects.toBeInstanceOf(ConflictStatusException);
+  });
+
+  it("정원 초과는 409 에러", async () => {
+    // Given
+    const host = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "host3@example.com",
+        passwordHash: "x",
+      })
+    );
+    const user1 = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "u3-1@example.com",
+        passwordHash: "x",
+      })
+    );
+    const user2 = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "u3-2@example.com",
+        passwordHash: "x",
+      })
+    );
+    const mclass = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(MClassEntity, {
+        title: "Full Class",
+        description: null,
+        maxParticipants: 1,
+        hostId: host.id,
+      })
+    );
+
+    await service.apply(new ApplyMClassCommand(mclass.id, user1.id));
+    await expect(
+      service.apply(new ApplyMClassCommand(mclass.id, user2.id))
+    ).rejects.toBeInstanceOf(ConflictStatusException);
+  });
+
+  it("존재하지 않는 클래스는 404 에러", async () => {
+    const user = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "user404@example.com",
+        passwordHash: "x",
+      })
+    );
+    await expect(
+      service.apply(new ApplyMClassCommand("999999", user.id))
+    ).rejects.toBeInstanceOf(ResourceNotFoundException);
+  });
+
+  it("아직 시작 전인 경우 409 에러", async () => {
+    // Given
+    const host = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "host-future@example.com",
+        passwordHash: "x",
+      })
+    );
+    const user = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "user-future@example.com",
+        passwordHash: "x",
+      })
+    );
+    const startAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const mclass = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(MClassEntity, {
+        title: "Not Started Class",
+        description: null,
+        maxParticipants: 10,
+        hostId: host.id,
+        startAt,
+      })
+    );
+
+    // When & Then
+    await expect(
+      service.apply(new ApplyMClassCommand(mclass.id, user.id))
+    ).rejects.toBeInstanceOf(ConflictStatusException);
+  });
+
+  it("마감(종료)된 경우 409 에러", async () => {
+    // Given
+    const host = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "host-ended@example.com",
+        passwordHash: "x",
+      })
+    );
+    const user = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(UserEntity, {
+        email: "user-ended@example.com",
+        passwordHash: "x",
+      })
+    );
+    const endAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const mclass = await OrmDataSource.manager.save(
+      OrmDataSource.manager.create(MClassEntity, {
+        title: "Ended Class",
+        description: null,
+        maxParticipants: 10,
+        hostId: host.id,
+        endAt,
+      })
+    );
+
+    // When & Then
+    await expect(
+      service.apply(new ApplyMClassCommand(mclass.id, user.id))
+    ).rejects.toBeInstanceOf(ConflictStatusException);
+  });
+});


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가(테스트 추가)
- [ ] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> 변경 범위와 핵심 내용을 요약했습니다.

- 신규 API: 내가 신청한 클래스 목록 조회
  - 엔드포인트: `GET /users/me/applications` (인증 필요, Bearer)
  - 응답 스키마: `ResponseDto<{ applicationId, mclassId, title, appliedAt }[]>`
  - 주요 파일
    - `src/api/public/user/user.router.ts`: 라우트 및 OpenAPI 등록
    - `src/api/public/user/user.controller.ts`: `getMyApplications`
    - `src/api/public/user/user.service.ts`: `getMyApplications` 서비스 로직
    - `src/api/public/user/dto/info/get-my-application-info.dto.ts`: DTO
    - `src/api/public/user/dto/response/get-my-applications-response.dto.ts`: Response DTO

- 클래스 신청 동시성 보장 로직 정비
  - `PublicMClassService#apply` 트랜잭션 처리
    - 대상 클래스 행에 대해 비관적 락(`pessimistic_write`)
    - 상태/정원 검증 후 신청 `INSERT` → `appliedCount` 증가
    - 중복 신청은 DB UNIQUE 키 충돌을 `409 Conflict`로 매핑
  - 주요 파일
    - `src/api/public/mclass/mclass.service.ts`
    - 참고: `src/orm/entity/Application.entity.ts` 내 `@Index('uk_app_user_class', ['userId','mclassId'], { unique: true })`

- 통합/동시성 테스트 추가
  - `test/integration/mclass/public-mclass.service.integration.spec.ts`
    - 최초 신청 성공, 중복 신청 409, 정원 초과 409, 존재하지 않는 클래스 404, 시작 전/종료 후 409 등 시나리오 검증
  - `test/integration/mclass/public-mclass.concurrency.integration.spec.ts`
    - 동시 50명 신청 시 단 1건만 성공, 나머지 실패 확인

- 문서
  - 설계 문서 `README.md`로 이관 및 보강

## 2️⃣ 작업내용 추가 설명
> 구현 근거와 배경을 요약했습니다.

- 동시성 제어 설계
  - DB 레벨 중복 방지: `applications(userId, mclassId)` UNIQUE 인덱스
  - 트랜잭션 + 행 단위 비관적 락
    - 단일 트랜잭션에서 상태/정원 검증 → INSERT → `appliedCount` 증가
    - 경쟁 상황에서도 정확히 1건만 성공하도록 보장
- 테스트 전략
  - `OrmDataSource.synchronize(true)`로 테스트 격리
  - `Promise.allSettled` 기반 동시 50요청 시뮬레이션
  - 성공 1건, 실패 49건(assert)로 레이스 컨디션 재현 및 방어 확인

```mermaid
%%{init: {'theme': 'dark'}}%%
sequenceDiagram
  participant U1 as User(1..50)
  participant API as PublicMClassService.apply
  participant DB as DB (MClass, Application)

  rect rgba(100,100,100,0.15)
  Note over API,DB: 단일 트랜잭션
  U1->>+API: POST /mclasses/{id}/apply
  API->>+DB: SELECT mclass FOR UPDATE
  DB-->>API: mclass row (locked)
  API->>DB: INSERT INTO applications(userId, mclassId)
  alt UNIQUE 충돌
    DB-->>API: ER_DUP_ENTRY
    API-->>U1: 409 Conflict
  else 첫 성공
    DB-->>API: Insert OK
    API->>DB: UPDATE mclass SET appliedCount = appliedCount + 1
    DB-->>API: Update OK
    API-->>U1: 201 Created
  end
  end
```

## 3️⃣ 이슈
> 영향 및 주의사항을 정리했습니다.

- API 변화
  - 신규 엔드포인트 추가(`GET /users/me/applications`), 기존 API에는 변경 없음
- 데이터베이스
  - 중복 신청 방지는 `applications(userId, mclassId)` UNIQUE 제약 기반으로 동작
- 리스크/주의
  - 비관적 락은 해당 클래스 행에 한정된 단기 잠금으로 데드락 가능성 낮음
  - 고동시성 트래픽 시에도 단 1건 성공을 보장함을 테스트로 검증
- 환경/의존성
  - 추가/변경 없음

- 변경 파일 하이라이트
  - `src/api/public/user/*` 일체 (신규 목록 조회 API)
  - `src/api/public/mclass/mclass.service.ts` (동시성 제어)
  - `test/integration/mclass/*.spec.ts` (통합/동시성 테스트)
  - `README.md` (설계 문서 이관)


- 주요 커밋
  - `28f5ec5` feat: 유저가 수강한 수강 리스트 조회 API 구현
  - `40a8696` docs: README로 설계문서 이관
  - `01f7933` test: 클래스 신청 API 통합테스트와 동시성 테스트 추가


- 요청/응답 예시 요약
  - 요청: `GET /users/me/applications` (Authorization: Bearer)
  - 응답 바디 예시
    ```json
    {
      "success": true,
      "message": "Success",
      "body": [
        {
          "applicationId": "123",
          "mclassId": "456",
          "title": "Concurrency Class",
          "appliedAt": "2025-08-11T06:41:24.000Z"
        }
      ]
    }
    ```


- 테스트 요약
  - 동시성: 50명 동시 신청 → 성공 1, 실패 49 검증
  - 예외 흐름: 중복 409, 정원 초과 409, 시작 전 409, 종료 후 409, 미존재 404


- 문서
  - `README.md`로 설계 문서 이관


- 기타
  - 브레이킹 체인지 없음


- 참고 파일
  - `src/api/public/user/user.router.ts`
  - `src/api/public/user/user.controller.ts`
  - `src/api/public/user/user.service.ts`
  - `src/api/public/mclass/mclass.service.ts`
  - `test/integration/mclass/public-mclass.concurrency.integration.spec.ts`
  - `test/integration/mclass/public-mclass.service.integration.spec.ts`
